### PR TITLE
Fixed bug in SoundPlayer.cs Stop() method by adding a CanSeek check b…

### DIFF
--- a/Src/Components/SoundPlayer.cs
+++ b/Src/Components/SoundPlayer.cs
@@ -213,8 +213,14 @@ public sealed class SoundPlayer(ISoundDataProvider dataProvider) : SoundComponen
     /// <inheritdoc />
     public void Stop()
     {
-        Pause();
-        Seek(0);
+        if (dataProvider.CanSeek)
+        {
+            Pause();
+            Seek(0);
+        }
+
+        Enabled = false;
+        State = PlaybackState.Stopped;
     }
     
     /// <inheritdoc cref="ISoundPlayer"/>


### PR DESCRIPTION
This PR resolves issue #16. 

There's a call to `Seek()` within the `Stop()` method of [SoundPlayer.cs](https://github.com/LSXPrime/SoundFlow/blob/master/Src/Components/SoundPlayer.cs#L217) which sets the playback position to 0. Given that web streams don't have a start time, this throws the `InvalidOperationException` contained within the Seek() method.

Adding a check within the Stop() method to see if the DataProvider can seek appears to resolve the issue. Moreover, I added some code so that if the provider can't seek, then a proper stop state is created:

```csharp
public void Stop()
{
    if (dataProvider.CanSeek)
    {
        Pause();
        Seek(0);
    }

    Enabled = false;
    State = PlaybackState.Stopped;
}
```