### PR TITLE
refactor: Raw audio sample support for AssetDataProvider

### DIFF
--- a/Extensions/SoundFlow.Extensions.WebRtc.Apm/AudioProcessingModule.cs
+++ b/Extensions/SoundFlow.Extensions.WebRtc.Apm/AudioProcessingModule.cs
@@ -3,6 +3,8 @@ using System.Runtime.InteropServices;
 
 namespace SoundFlow.Extensions.WebRtc.Apm;
 
+#pragma warning disable CS1591
+
 /// <summary>
 /// Error codes returned by the WebRTC Audio Processing Module
 /// </summary>
@@ -61,6 +63,7 @@ public enum RuntimeSettingType
     CapturePostGain,
     CaptureOutputUsed
 }
+#pragma warning restore CS1591
 
 /// <summary>
 /// Represents a stream configuration for audio processing
@@ -797,7 +800,7 @@ public class AudioProcessingModule : IDisposable
 public static class NativeMethods
 {
     private const string LibraryName = "webrtc-apm";
-    
+
     static NativeMethods()
     {
         NativeLibrary.SetDllImportResolver(typeof(NativeMethods).Assembly, NativeLibraryResolver.Resolve);
@@ -809,12 +812,12 @@ public static class NativeMethods
         {
             if (NativeLibrary.TryLoad(LibraryName, out var library))
                 return library;
-            
+
             var libraryPath = GetLibraryPath(LibraryName);
             // Safeguard against dotnet cli working directory inconsistency
             if (!File.Exists(libraryPath))
                 libraryPath = $"{Path.GetDirectoryName(assembly.Location)}/{libraryPath}";
-            
+
             return NativeLibrary.Load(libraryPath);
         }
 
@@ -881,6 +884,7 @@ public static class NativeMethods
         }
     }
 
+#pragma warning disable CS1591
     [DllImport(LibraryName, EntryPoint = "webrtc_apm_create", CallingConvention = CallingConvention.Cdecl)]
     public static extern IntPtr webrtc_apm_create();
 
@@ -1045,4 +1049,6 @@ public static class NativeMethods
 
     [DllImport(LibraryName, EntryPoint = "webrtc_apm_get_frame_size", CallingConvention = CallingConvention.Cdecl)]
     public static extern UIntPtr webrtc_apm_get_frame_size(int sample_rate_hz);
+    
+    #pragma warning restore CS1591
 }

--- a/Src/Enums/Result.cs
+++ b/Src/Enums/Result.cs
@@ -1,4 +1,6 @@
-﻿namespace SoundFlow.Enums;
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace SoundFlow.Enums;
 
 /// <summary>
 /// Describes the result of an operation.
@@ -85,3 +87,5 @@ public enum Result
     FailedToStartBackendDevice = -402,
     FailedToStopBackendDevice = -403
 }
+
+#pragma warning restore CS1591

--- a/Src/Providers/AssetDataProvider.cs
+++ b/Src/Providers/AssetDataProvider.cs
@@ -38,6 +38,18 @@ public sealed class AssetDataProvider : ISoundDataProvider
     {
     }
 
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="AssetDataProvider" /> class.
+    /// </summary>
+    /// <param name="data">The raw audio data.</param>
+    /// <param name="sampleRate">The sample rate of the audio data.</param>
+    public AssetDataProvider(float[] data, int? sampleRate = null)
+    {
+        _data = data;
+        SampleRate = sampleRate;
+        Length = _data.Length;
+    }
+
     /// <inheritdoc />
     public int Position => _samplePosition;
 
@@ -130,5 +142,4 @@ public sealed class AssetDataProvider : ISoundDataProvider
         _data = null!;
         _isDisposed = true;
     }
-
 }


### PR DESCRIPTION
- Add a constructor that accepts raw audio sample data
- disable some warnings around self-descriptive enum names