### PR TITLE
feat: Implement stream-based audio encoding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,21 +38,21 @@ jobs:
             toolchain: "Visual Studio 17 2022"
 
           # Linux builds
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             rid: linux-x64
             platform: Linux
             arch: x86_64
             cmake_target_arch: x64
             lib_extension: ".so"
 
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             rid: linux-arm
             platform: Linux
             arch: armv7l
             cmake_target_arch: arm
             lib_extension: ".so"
 
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             rid: linux-arm64
             platform: Linux
             arch: aarch64
@@ -83,21 +83,21 @@ jobs:
             lib_extension: ".framework"
 
           # Android builds
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             rid: android-arm
             platform: Android
             arch: armeabi-v7a
             cmake_target_arch: armeabi-v7a
             lib_extension: ".so"
 
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             rid: android-arm64
             platform: Android
             arch: arm64-v8a
             cmake_target_arch: arm64-v8a
             lib_extension: ".so"
 
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             rid: android-x64
             platform: Android
             arch: x86_64
@@ -149,7 +149,7 @@ jobs:
 
       # Linux/Android dependencies
       - name: Install Dependencies (Linux)
-        if: matrix.os == 'ubuntu-latest' && matrix.platform == 'Linux'
+        if: matrix.platform == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake gcc g++
@@ -262,7 +262,7 @@ jobs:
           readelf -d "$LIB_PATH"
 
       - name: Analyze Dependencies (Linux)
-        if: matrix.os == 'ubuntu-latest' && matrix.platform == 'Linux'
+        if: matrix.platform == 'Linux'
         shell: bash
         run: |
           LIB_PATH="runtimes/${{ matrix.rid }}/native/libminiaudio.so"
@@ -270,7 +270,7 @@ jobs:
           ldd "$LIB_PATH"
 
       - name: Analyze Dependencies (macOS)
-        if: matrix.os == 'macos-latest' && matrix.platform == 'macOS'
+        if: matrix.platform == 'macOS'
         shell: bash
         run: |
           LIB_PATH="runtimes/${{ matrix.rid }}/native/libminiaudio.dylib"
@@ -285,7 +285,7 @@ jobs:
 
   package:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/Samples/SoundFlow.Samples.EditingMixer/SpeechBasedExamples.cs
+++ b/Samples/SoundFlow.Samples.EditingMixer/SpeechBasedExamples.cs
@@ -144,11 +144,6 @@ public static class SpeechBasedExamples
 
     private static void PlayComposition(Composition composition, string message = "Playing composition...")
     {
-        var encoder = AudioEngine.Instance.CreateEncoder($"{composition.Name}.wav", EncodingFormat.Wav, SampleFormat.F32, 1, 24000);
-        var render = composition.Render(TimeSpan.Zero, composition.CalculateTotalDuration());
-        encoder.Encode(render);
-        encoder.Dispose();
-        
         Console.WriteLine(message);
         var player = new SoundPlayer(composition);
         Mixer.Master.AddComponent(player);

--- a/Samples/SoundFlow.Samples.NoiseSuppression/Program.cs
+++ b/Samples/SoundFlow.Samples.NoiseSuppression/Program.cs
@@ -181,7 +181,8 @@ class Program
             suppressionLevel: NoiseSuppressionLevel.VeryHigh,
             useMultichannelProcessing: false
         );
-        var encoder = AudioEngine.Instance.CreateEncoder(CleanedFilePath, EncodingFormat.Wav, SampleFormat.F32, 1, 48000);
+        var stream = new FileStream(CleanedFilePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096);
+        var encoder = AudioEngine.Instance.CreateEncoder(stream, EncodingFormat.Wav, SampleFormat.F32, 1, 48000);
         
         // Process the noisy speech file and save the cleaned audio
         Console.WriteLine("Processing noisy speech file...");
@@ -189,6 +190,7 @@ class Program
         var cleanData = noiseSuppressor.ProcessAll();
         encoder.Encode(cleanData.AsSpan());
         encoder.Dispose();
+        stream.Dispose();
         
         Console.WriteLine($"Noise suppression applied. Cleaned audio file saved as 'cleaned-audio.wav' at {CleanedFilePath}, Press any key to exit.");
         Console.ReadLine();

--- a/Samples/SoundFlow.Samples.SimplePlayer/ComponentTests.cs
+++ b/Samples/SoundFlow.Samples.SimplePlayer/ComponentTests.cs
@@ -154,11 +154,12 @@ internal static class ComponentTests
         _audioEngine.Dispose();
         _audioEngine = new MiniAudioEngine(48000, Capability.Record);
 
-        var recorder =
-            new Recorder("output_recording.wav");
+        var stream = new FileStream("output_recording.wav", FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096);
+        var recorder = new Recorder(stream);
         recorder.StartRecording();
         Thread.Sleep(5000); // Record for 5 seconds
         recorder.StopRecording();
+        stream.Dispose();
         Console.WriteLine("Recording stopped and saved to 'output_recording.wav'.");
     }
 

--- a/Samples/SoundFlow.Samples.SimplePlayer/Program.cs
+++ b/Samples/SoundFlow.Samples.SimplePlayer/Program.cs
@@ -8,7 +8,6 @@ using SoundFlow.Interfaces;
 using SoundFlow.Modifiers;
 using SoundFlow.Providers;
 using SoundFlow.Visualization;
-using VoiceActivityDetector = SoundFlow.Components.VoiceActivityDetector;
 
 namespace SoundFlow.Samples.SimplePlayer;
 
@@ -271,7 +270,8 @@ internal static class Program
     {
         SetOrCreateEngine(Capability.Record);
         
-        using var recorder = new Recorder(RecordedFilePath, SampleFormat.F32, EncodingFormat.Wav, 48000);
+        var stream = new FileStream(RecordedFilePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096);
+        using var recorder = new Recorder(stream, SampleFormat.F32, EncodingFormat.Wav, 48000);
 
         Console.WriteLine("Recording started. Press 's' to stop, 'p' to pause/resume.");
         recorder.StartRecording();
@@ -301,6 +301,8 @@ internal static class Program
         }
 
         Console.WriteLine("Recording finished. Press 'p' to playback or any other key to exit.");
+        Console.WriteLine($"Recorded file: {RecordedFilePath}");
+        stream.Dispose();
         if (Console.ReadKey(true).Key != ConsoleKey.P)
             return;
 

--- a/Src/Abstracts/AudioEngine.cs
+++ b/Src/Abstracts/AudioEngine.cs
@@ -336,13 +336,13 @@ public abstract class AudioEngine : IDisposable
     /// <summary>
     ///     Constructs a sound encoder specific to the implementation.
     /// </summary>
-    /// <param name="filePath">The path to the file to write encoded audio to.</param>
+    /// <param name="stream">The stream to write encoded audio to.</param>
     /// <param name="encodingFormat">The desired audio encoding format.</param>
     /// <param name="sampleFormat">The format of the input audio samples.</param>
     /// <param name="channels">The number of audio channels.</param>
     /// <param name="sampleRate">The sample rate of the input audio.</param>
     /// <returns>An instance of a sound encoder.</returns>
-    public abstract ISoundEncoder CreateEncoder(string filePath, EncodingFormat encodingFormat,
+    public abstract ISoundEncoder CreateEncoder(Stream stream, EncodingFormat encodingFormat,
         SampleFormat sampleFormat, int channels, int sampleRate);
 
     /// <summary>

--- a/Src/Backends/MiniAudio/MiniAudioEncoder.cs
+++ b/Src/Backends/MiniAudio/MiniAudioEncoder.cs
@@ -1,4 +1,5 @@
 ﻿using SoundFlow.Abstracts;
+using SoundFlow.Backends.MiniAudio.Enums;
 using SoundFlow.Enums;
 using SoundFlow.Exceptions;
 using SoundFlow.Interfaces;
@@ -11,30 +12,34 @@ namespace SoundFlow.Backends.MiniAudio;
 internal sealed unsafe class MiniAudioEncoder : ISoundEncoder
 {
     private readonly nint _encoder;
-    public string FilePath { get; }
+    private readonly Stream _stream;
+    private readonly Native.BufferProcessingCallback _writeCallback;
+    private readonly Native.SeekCallback _seekCallback;
+    private readonly object _syncLock = new();
 
     /// <summary>
-    /// Constructs a new encoder to write to the given file in the specified format.
+    /// Constructs a new encoder to write to the given stream in the specified format.
     /// </summary>
-    /// <param name="filePath">The path to the file to write encoded audio to.</param>
+    /// <param name="stream">The stream to write encoded audio to.</param>
     /// <param name="encodingFormat">The desired audio encoding format.</param>
     /// <param name="sampleFormat">The format of the input audio samples.</param>
     /// <param name="channels">The number of audio channels.</param>
     /// <param name="sampleRate">The sample rate of the input audio.</param>
-    public MiniAudioEncoder(string filePath, EncodingFormat encodingFormat, SampleFormat sampleFormat, int channels,
+    public MiniAudioEncoder(Stream stream, EncodingFormat encodingFormat, SampleFormat sampleFormat, int channels,
         int sampleRate)
     {
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+
         if (encodingFormat != EncodingFormat.Wav)
             throw new NotSupportedException("MiniAudio only supports WAV encoding.");
         
-        FilePath = filePath;
-
         // Construct encoder config
         var config = Native.AllocateEncoderConfig(encodingFormat, sampleFormat, (uint)channels, (uint)sampleRate);
 
         // Allocate encoder and initialize
         _encoder = Native.AllocateEncoder();
-        var result = Native.EncoderInitFile(filePath, config, _encoder);
+        var result = Native.EncoderInit(_writeCallback = WriteCallback, _seekCallback = SeekCallback, nint.Zero, config, _encoder);
+        
         if (result != Result.Success)
             throw new BackendException("MiniAudio", result, "Unable to initialize encoder.");
     }
@@ -43,43 +48,99 @@ internal sealed unsafe class MiniAudioEncoder : ISoundEncoder
     public bool IsDisposed { get; private set; }
 
     /// <summary>
-    /// Encodes the given samples and writes them to the output file.
+    /// Encodes the given samples and writes them to the output stream.
     /// </summary>
     /// <param name="samples">The buffer containing the PCM samples to encode.</param>
     /// <returns>The number of samples successfully encoded.</returns>
     public int Encode(Span<float> samples)
     {
-        var framesToWrite = (ulong)(samples.Length / AudioEngine.Channels);
-        ulong framesWritten = 0;
-
-        fixed (float* pSamples = samples)
+        lock (_syncLock)
         {
-            var result = Native.EncoderWritePcmFrames(_encoder, (nint)pSamples, framesToWrite, &framesWritten);
-            if (result != Result.Success)
-                throw new BackendException("MiniAudio", result, "Failed to write PCM frames to encoder.");
-        }
+            if (IsDisposed)
+                return 0;
 
-        return (int)framesWritten * AudioEngine.Channels;
+            var framesToWrite = (ulong)(samples.Length / AudioEngine.Channels);
+            ulong framesWritten = 0;
+
+            fixed (float* pSamples = samples)
+            {
+                var result = Native.EncoderWritePcmFrames(_encoder, (nint)pSamples, framesToWrite, &framesWritten);
+                if (result != Result.Success)
+                    throw new BackendException("MiniAudio", result, "Failed to write PCM frames to encoder.");
+            }
+
+            return (int)framesWritten * AudioEngine.Channels;
+        }
     }
 
+    /// <summary>
+    /// Disposes of the encoder resources.
+    /// </summary>
     public void Dispose()
     {
         Dispose(true);
         GC.SuppressFinalize(this);
     }
 
+    /// <summary>
+    /// Finalizer for the <see cref="MiniAudioEncoder"/> class.
+    /// </summary>
     ~MiniAudioEncoder()
     {
         Dispose(false);
     }
 
-    private void Dispose(bool disposing)
+    /// <summary>
+    /// Callback method for MiniAudio to write encoded data to the stream.
+    /// MiniAudio provides the encoded data in <paramref name="pBufferIn"/>,
+    /// which is then written to the internal <see cref="_stream"/>.
+    /// </summary>
+    private Result WriteCallback(nint pEncoder, nint pBufferIn, ulong bytesToWrite, out ulong* pBytesWritten)
     {
-        if (!IsDisposed)
+        lock (_syncLock)
         {
-            if (disposing)
-                Native.EncoderUninit(_encoder);
+            if (!_stream.CanWrite)
+            {
+                pBytesWritten = (ulong*)0;
+                return Result.NoDataAvailable;
+            }
+
+            var bytes = new ReadOnlySpan<byte>((void*)pBufferIn, (int)bytesToWrite);
+            _stream.Write(bytes);
             
+            pBytesWritten = (ulong*)bytesToWrite;
+            return Result.Success;
+        }
+    }
+
+    /// <summary>
+    /// Callback method for MiniAudio to seek the output stream.
+    /// </summary>
+    private Result SeekCallback(nint pEncoder, long byteOffset, SeekPoint point)
+    {
+        lock (_syncLock)
+        {
+            if (!_stream.CanSeek)
+                return Result.NoDataAvailable;
+
+            if (byteOffset >= 0 && byteOffset < _stream.Length - 1)
+                _stream.Seek(byteOffset, point == SeekPoint.FromCurrent ? SeekOrigin.Current : SeekOrigin.Begin);
+            
+            return Result.Success;
+        }
+    }
+    
+    private void Dispose(bool _)
+    {
+        lock (_syncLock)
+        {
+            if (IsDisposed) return;
+
+            // Keep delegates alive
+            GC.KeepAlive(_writeCallback);
+            GC.KeepAlive(_seekCallback);
+
+            Native.EncoderUninit(_encoder);
             Native.Free(_encoder);
 
             IsDisposed = true;

--- a/Src/Backends/MiniAudio/MiniAudioEngine.cs
+++ b/Src/Backends/MiniAudio/MiniAudioEngine.cs
@@ -107,10 +107,10 @@ public sealed class MiniAudioEngine(
 
 
     /// <inheritdoc />
-    public override ISoundEncoder CreateEncoder(string filePath, EncodingFormat encodingFormat,
+    public override ISoundEncoder CreateEncoder(Stream stream, EncodingFormat encodingFormat,
         SampleFormat sampleFormat, int encodingChannels, int sampleRate)
     {
-        return new MiniAudioEncoder(filePath, encodingFormat, sampleFormat, encodingChannels, sampleRate);
+        return new MiniAudioEncoder(stream, encodingFormat, sampleFormat, encodingChannels, sampleRate);
     }
 
     /// <inheritdoc />

--- a/Src/Editing/Persistence/CompositionProjectManager.cs
+++ b/Src/Editing/Persistence/CompositionProjectManager.cs
@@ -204,16 +204,16 @@ public static class CompositionProjectManager
 
                     if (samplesRead == totalSamples && totalSamples > 0)
                     {
-                        
                         // ISoundDataProvider doesn't expose its native channel count. This is a limitation.
                         // For now, I will use the composition's target channels for the encoded WAV.
                         // This means mono sources might become stereo, or vice versa, if compositionTargetChannels differs.
                         // TODO: refactor when support for getting audio data is added (e.g., mono, stereo, 5.1 or 7.1, etc.)
                         var encSr = provider.SampleRate;
                         const SampleFormat encFormat = SampleFormat.F32;
-                        using var encoder = AudioEngine.Instance.CreateEncoder(
-                            consolidatedFilePath, EncodingFormat.Wav, encFormat, compositionTargetChannels, encSr);
+                        var stream = new FileStream(consolidatedFilePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096);
+                        using var encoder = AudioEngine.Instance.CreateEncoder(stream, EncodingFormat.Wav, encFormat, compositionTargetChannels, encSr);
                         encoder.Encode(tempBuffer.AsSpan(0, samplesRead));
+                        await stream.DisposeAsync();
 
                         sourceRef.OriginalSampleFormat = encFormat;
                         sourceRef.OriginalSampleRate = encSr;


### PR DESCRIPTION
- Update AudioEngine to use Stream instead of file paths for encoding
- Refactor MiniAudioEncoder to support writing to any stream via callbacks
- Modify Recorder to work with streams rather than file paths
- Update all samples and CompositionProjectManager to use streams
- Update CI workflow to use ubuntu-22.04 instead of ubuntu-latest
- Clean up MiniAudio native callbacks and add proper documentation

BREAKING CHANGE: The CreateEncoder method and Recorder class now require a Stream parameter instead of a file path string. All file-based encoding operations must be updated to use streams.