### PR TITLE
fix(readme): #95 Fix example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,15 @@ var defaultDevice = engine.PlaybackDevices.FirstOrDefault(x => x.IsDefault);
 using var playbackDevice = engine.InitializePlaybackDevice(defaultDevice, format);
 
 // 4. Create a SoundPlayer to play an audio file.
-var player = new SoundPlayer(engine, device.Format,
+var player = new SoundPlayer(engine, playbackDevice.Format,
     new StreamDataProvider(engine, format, File.OpenRead("path/to/your/audiofile.wav")));
 
 // 5. Add the player to the device's MasterMixer.
 // Each device has its own independent mixer.
-device.MasterMixer.AddComponent(player);
+playbackDevice.MasterMixer.AddComponent(player);
 
 // 6. Start the device to begin audio processing.
-device.Start();
+playbackDevice.Start();
 player.Play();
 
 // Keep the console application running.
@@ -102,7 +102,7 @@ Console.ReadKey();
 
 // Stop and clean up.
 player.Stop();
-device.Stop();
+playbackDevice.Stop();
 ```
 
 ## Core Concepts


### PR DESCRIPTION
### **User description**
addresses #95 

I was trying to test out this library and noticed the example didn't compile. Please let me know if you would prefer something else end up in the readme.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fix variable name inconsistency in README example

- Replace incorrect `device` references with `playbackDevice`

- Ensure example code compiles and runs correctly


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README.md example code"] -- "Fix variable references" --> B["Replace device with playbackDevice"]
  B -- "Correct 4 occurrences" --> C["Compilable example"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Fix variable naming in audio playback example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Fixed variable name from <code>device</code> to <code>playbackDevice</code> in 4 locations<br> <li> Line 88: SoundPlayer constructor parameter<br> <li> Line 92: MasterMixer.AddComponent call<br> <li> Line 95: device.Start() call<br> <li> Line 105: device.Stop() call</ul>


</details>


  </td>
  <td><a href="https://github.com/LSXPrime/SoundFlow/pull/96/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

